### PR TITLE
Fix adaptive icons on Samsung phones

### DIFF
--- a/TMessagesProj/src/main/AndroidManifest.xml
+++ b/TMessagesProj/src/main/AndroidManifest.xml
@@ -378,7 +378,6 @@
 
         <meta-data android:name="com.google.android.gms.vision.DEPENDENCIES" android:value="face" />
 
-        <meta-data android:name="com.samsung.android.icon_container.has_icon_container" android:value="true"/>
         <meta-data android:name="android.max_aspect" android:value="2.5" />
 
     </application>


### PR DESCRIPTION
Please, stop following that idiot "designer" Josh Burton: https://medium.com/@AthorNZ/disabling-touchwiz-icon-frames-c7cb4b626180

His stance is totally unacceptable, and screws with a system-level part of Samsung phones. Just... don't use it. At all.

Removing this line from the manifest will allow Samsung's own framework (let it be Grace UX or OneUI) to properly make an adapted icon shape for their own launcher. It's a quite unsightly thing to see all icons as nice squircles, except for Telegram, which will appear as a circle icon no matter what.